### PR TITLE
Add `mutex_m` as a runtime dependency

### DIFF
--- a/as-notifications.gemspec
+++ b/as-notifications.gemspec
@@ -14,5 +14,7 @@ Gem::Specification.new do |s|
   s.files        = Dir['MIT-LICENSE', 'README.md', 'lib/**/*']
   s.require_path = 'lib'
 
-  s.rdoc_options.concat ['--encoding',  'UTF-8']
+  s.rdoc_options.concat ['--encoding', 'UTF-8']
+
+  s.add_runtime_dependency 'mutex_m'
 end


### PR DESCRIPTION
### Context

The `as-notifications` gem uses `mutex_m` from the Ruby standard library:

https://github.com/bernd/as-notifications/blob/d1a8d7ed09be01dadacd30649802d6a7885c2c4b/lib/as/notifications/fanout.rb#L1

In the forthcoming Ruby 3.4, the `mutex_m` library will be come a 'bundled' library. It must be included in gem sets to be used with Bundler.

In [Ruby 3.3](https://www.ruby-lang.org/en/news/2023/12/25/ruby-3-3-0-released/) a deprecation warning is shown:

> lib/as/notifications/fanout.rb:1: warning: mutex_m was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add mutex_m to your Gemfile or gemspec.

Example: https://github.com/bernd/as-notifications/actions/runs/7948119632/job/21697771073#step:4:6

### Change

Add `mutex_m` as a runtime dependency in the gemspec.